### PR TITLE
Update config for kibana 6.1.4

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,8 +1,8 @@
 {
   "type": "config",
-  "updated_at": "2018-02-19T14:29:37.545Z",
+  "updated_at": "2018-07-05T11:26:34.541Z",
   "config": {
-    "buildNum": 16350,
+    "buildNum": 16380,
     "defaultIndex": "giantswarm",
     "dateFormat:tz": "UTC",
     "dateFormat": "YYYY-MM-DD HH:mm:ss",

--- a/write-config.sh
+++ b/write-config.sh
@@ -56,7 +56,7 @@ do
   curl -s -XPUT \
     -H 'Content-Type: application/json' \
     -d @config/config.json \
-    "${ELASTICSEARCH_ENDPOINT}/${INDEX}/doc/config:6.1.1"
+    "${ELASTICSEARCH_ENDPOINT}/${INDEX}/doc/config:${KIBANA_VERSION}"
   echo ""
 
   sleep 3600


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/3650

This replaces the hard coded Kibana version string with an environment variable introduced in https://github.com/giantswarm/g8s-efk/pull/59

It also updates the build number. Not sure if that's necessary, but this is what our current Kibana version writes into the config.